### PR TITLE
Attempt to fix the MIT license to get recognized from pkg.go.dev

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-MIT License
-
 Copyright (c) [2020] [Felix Wieland]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
MIT License is currently not detected by "pkg.go.dev"