### PR TITLE
Allow use of different http servers

### DIFF
--- a/examples/nested/nested.go
+++ b/examples/nested/nested.go
@@ -4,11 +4,17 @@ import (
 	"github.com/FelixWieland/kosmo"
 )
 
+//ToIgnore should be ignored
+type ToIgnore struct {
+	field uint64 //this should fail
+}
+
 //Root -
 type Root struct {
-	ID    int
-	Name  string
-	Child Child
+	ToIgnore `kosmo:"ignore"`
+	ID       int
+	Name     string
+	Child    Child
 }
 
 //Child -

--- a/examples/nested/nested.go
+++ b/examples/nested/nested.go
@@ -17,6 +17,7 @@ type Child struct {
 	Name string
 }
 
+//GetRoot -
 func GetRoot() (Root, error) {
 	return Root{
 		ID:   1,
@@ -24,6 +25,7 @@ func GetRoot() (Root, error) {
 	}, nil
 }
 
+//GetAnotherRoot -
 func GetAnotherRoot() (Root, error) {
 	return Root{
 		ID:   1,
@@ -31,6 +33,7 @@ func GetAnotherRoot() (Root, error) {
 	}, nil
 }
 
+//GetChild -
 func GetChild() (Child, error) {
 	return Child{
 		ID:   1,

--- a/kosmo.go
+++ b/kosmo.go
@@ -21,7 +21,7 @@ type HTTPConfig struct {
 	Gzip       bool
 }
 
-// GraphQLConfig represents the graphql configuraiton options
+// GraphQLConfig represents the graphql configuration options
 type GraphQLConfig struct {
 	RemoveResolverPrefixes bool
 	ResolverPrefixes       []string

--- a/kosmo.go
+++ b/kosmo.go
@@ -136,3 +136,13 @@ func (s *Service) Server() *http.Server {
 
 	return muxServer(s.HTTPConfig, schema)
 }
+
+//Handler - returns the raw HTTP handler
+func (s *Service) Handler() http.Handler {
+	schema, err := graphql.NewSchema(s.graphQL)
+	if err != nil {
+		panic(err)
+	}
+
+	return rawHandler(s.HTTPConfig.Playground, schema)
+}

--- a/reflector.go
+++ b/reflector.go
@@ -15,6 +15,10 @@ func runtimeFunctionName(function reflect.Value) string {
 func reflectStructInformations(structType reflect.Type) (string, []reflect.StructField) {
 	fields := []reflect.StructField{}
 	for i := 0; i < structType.NumField(); i++ {
+		config := parseTagConfig(structType.Field(i).Tag.Get("kosmo"))
+		if config.Ignore {
+			continue
+		}
 		fields = append(fields, structType.Field(i))
 	}
 	return structType.Name(), fields

--- a/reflector_test.go
+++ b/reflector_test.go
@@ -32,7 +32,7 @@ func TestReflectStructInformations(t *testing.T) {
 		Convey(`The first return value (name) should be the name of the type of the passed in type`, func() {
 			So(name, ShouldEqual, "TReflectStructInformationsStruct")
 		})
-		Convey(`The second return value (fields) should have the lenght of the number of fields in that struct`, func() {
+		Convey(`The second return value (fields) should have the length of the number of fields in that struct`, func() {
 			So(len(fields), ShouldEqual, 3)
 		})
 		Convey(`Also should the second return value contains all Field names`, func() {

--- a/server.go
+++ b/server.go
@@ -14,11 +14,7 @@ func muxServer(config HTTPConfig, schema graphql.Schema) *http.Server {
 		config.APIBase = "/"
 	}
 
-	rawHandler := handler.New(&handler.Config{
-		Schema:   &schema,
-		Pretty:   true,
-		GraphiQL: config.Playground,
-	})
+	rawHandler := rawHandler(config.Playground, schema)
 
 	mux := http.NewServeMux()
 	server := http.Server{Addr: config.Port, Handler: mux}
@@ -31,4 +27,12 @@ func muxServer(config HTTPConfig, schema graphql.Schema) *http.Server {
 	}
 
 	return &server
+}
+
+func rawHandler(playground bool, schema graphql.Schema) *handler.Handler {
+	return handler.New(&handler.Config{
+		Schema:   &schema,
+		Pretty:   true,
+		GraphiQL: playground,
+	})
 }


### PR DESCRIPTION
Added a method to extract the RawHTTP Handler from the kosmo Service.
Additionally the possibility to ignore embedded fields was added.